### PR TITLE
Fixed wrong pointers to free and realloc

### DIFF
--- a/main/AppCommon.c
+++ b/main/AppCommon.c
@@ -941,7 +941,7 @@ STATUS freeApp(PAppConfiguration* ppAppConfiguration)
 
     app_webrtc_deinit(pAppConfiguration);
     if (pAppMediaSrc != NULL) {
-        pAppMediaSrc->app_media_source_detroy(&pAppConfiguration->pMediaContext);
+        pAppMediaSrc->app_media_source_destroy(&pAppConfiguration->pMediaContext);
     }
 
     if (IS_VALID_CVAR_VALUE(pAppConfiguration->cvar) && IS_VALID_MUTEX_VALUE(pAppConfiguration->appConfigurationObjLock)) {

--- a/main/AppMediaSrc_ESP32_FileSrc.c
+++ b/main/AppMediaSrc_ESP32_FileSrc.c
@@ -168,7 +168,7 @@ PVOID sendAudioPackets(PVOID args)
     while (!ATOMIC_LOAD_BOOL(&pFileSrcContext->shutdownFileSrc)) {
         fileIndex = fileIndex % NUMBER_OF_OPUS_FRAME_FILES + 1;
         snprintf(filePath, MAX_PATH_LEN, "/sdcard/opusSampleFrames/sample-%03d.opus", fileIndex);
-        
+
         CHK(readFrameFromDisk(NULL, &frameSize, filePath) == STATUS_SUCCESS, STATUS_MEDIA_AUDIO_SINK);
         // Re-alloc if needed
         if (frameSize > pCodecStreamConf->frameBufferSize) {
@@ -207,7 +207,7 @@ CleanUp:
     return (PVOID) (ULONG_PTR) retStatus;
 }
 
-STATUS app_media_source_detroy(PMediaContext* ppMediaContext)
+STATUS app_media_source_destroy(PMediaContext* ppMediaContext)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PFileSrcContext pFileSrcContext;
@@ -257,7 +257,7 @@ CleanUp:
 
     if (STATUS_FAILED(retStatus)) {
         if (pFileSrcContext != NULL) {
-            app_media_source_detroy(pFileSrcContext);
+            app_media_source_destroy((PMediaContext *) &pFileSrcContext);
         }
     }
 
@@ -379,5 +379,5 @@ AppMediaSrc gAppMediaSrc = {
     .app_media_source_run = app_media_source_run,
     .app_media_source_shutdown = app_media_source_shutdown,
     .app_media_source_isShutdown = NULL,
-    .app_media_source_detroy = app_media_source_detroy
+    .app_media_source_destroy = app_media_source_destroy
 };

--- a/main/include/AppMediaSrc.h
+++ b/main/include/AppMediaSrc.h
@@ -37,7 +37,7 @@ typedef struct __AppMediaSrc {
     PVOID (*app_media_source_run)(PVOID pArgs);
     STATUS (*app_media_source_shutdown)(PMediaContext pMediaContext);
     STATUS (*app_media_source_isShutdown)(PMediaContext pMediaContext, PBOOL pShutdown);
-    STATUS (*app_media_source_detroy)(PMediaContext* ppMediaContext);
+    STATUS (*app_media_source_destroy)(PMediaContext* ppMediaContext);
 } AppMediaSrc, *PAppMediaSrc;
 
 #ifdef __cplusplus

--- a/patch/0002-wss_api-Fix-wrong-pointer-to-request_info_free.patch
+++ b/patch/0002-wss_api-Fix-wrong-pointer-to-request_info_free.patch
@@ -1,0 +1,40 @@
+From c43c51edb21d9b0748cee752cb06353a14c79012 Mon Sep 17 00:00:00 2001
+From: Vikram Dattu <vikram.dattu@espressif.com>
+Date: Mon, 30 Sep 2024 18:13:43 +0530
+Subject: [PATCH] wss_api: Fix wrong pointer to request_info_free
+
+http_api: Fixed erroreous reallocs
+---
+ src/source/api_call/http_api.c | 2 +-
+ src/source/api_call/wss_api.c  | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/source/api_call/http_api.c b/src/source/api_call/http_api.c
+index 5b668b3dd..374eebc24 100644
+--- a/src/source/api_call/http_api.c
++++ b/src/source/api_call/http_api.c
+@@ -534,7 +534,7 @@ STATUS http_api_getIceConfig(PSignalingClient pSignalingClient, PUINT32 pHttpSta
+                                        uSendBufLen, FALSE, TRUE, NULL)) == STATUS_HTTP_BUF_OVERFLOW) {
+             DLOGD("The send buffer(%u) is not enough", uSendBufLen);
+             uSendBufLen <<= 1;
+-            CHK(NULL != (pHttpSendBuffer = (uint8_t*) MEMREALLOC(uSendBufLen, 1)), STATUS_HTTP_NOT_ENOUGH_MEMORY);
++            CHK(NULL != (pHttpSendBuffer = (uint8_t*) MEMREALLOC(pHttpSendBuffer, uSendBufLen)), STATUS_HTTP_NOT_ENOUGH_MEMORY);
+             uRetryAllocation--;
+         } else {
+             break;
+diff --git a/src/source/api_call/wss_api.c b/src/source/api_call/wss_api.c
+index 441915705..119179970 100644
+--- a/src/source/api_call/wss_api.c
++++ b/src/source/api_call/wss_api.c
+@@ -201,7 +201,7 @@ CleanUp:
+     SAFE_MEMFREE(pUrl);
+     SAFE_MEMFREE(pHttpSendBuffer);
+     SAFE_MEMFREE(pHttpRecvBuffer);
+-    request_info_free(pRequestInfo);
++    request_info_free(&pRequestInfo);
+ 
+     WSS_API_EXIT();
+     return retStatus;
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
 - AppMediaSrc_ESP32_FileSrc.c: Fix wrong pointer passed to app_media_source_destroy
 - Patch wss_api.c: Fix for wrong pointer passed to request_info_free
 - Fixed wrong realloc in http_api.c

*Issue #, if available:*

*Description of changes:*

This PR fixes a few instances where wrong pointers are used for free

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
